### PR TITLE
feat(color, typography, fontFamily, fontWeight, fontSize, lineHeight)…

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -1,0 +1,8616 @@
+{
+  "global": {
+    "lineHeights": {
+      "3": {
+        "value": "12",
+        "type": "lineHeights",
+        "description": "[leading-3] (0.75rem / 12px)"
+      },
+      "4": {
+        "value": "16",
+        "type": "lineHeights",
+        "description": "[leading-4] (1rem / 16px)"
+      },
+      "5": {
+        "value": "20",
+        "type": "lineHeights",
+        "description": "[leading-5] (1.25rem / 20px)"
+      },
+      "6": {
+        "value": "24",
+        "type": "lineHeights",
+        "description": "[leading-6] (1.5rem / 24px)"
+      },
+      "7": {
+        "value": "28",
+        "type": "lineHeights",
+        "description": "[leading-7] (1.75rem / 28px)"
+      },
+      "8": {
+        "value": "32",
+        "type": "lineHeights",
+        "description": "[leading-8] (2rem / 32px)"
+      },
+      "9": {
+        "value": "36",
+        "type": "lineHeights",
+        "description": "[leading-9] (2.25rem / 36px)"
+      },
+      "10": {
+        "value": "40",
+        "type": "lineHeights",
+        "description": "[leading-10] (2.5rem / 40px)"
+      },
+      "none": {
+        "value": "100%",
+        "type": "lineHeights",
+        "description": "[leading-none] (1 / 100%)"
+      },
+      "tight": {
+        "value": "125%",
+        "type": "lineHeights",
+        "description": "[leading-tight] (1.25 / 125%)"
+      },
+      "snug": {
+        "value": "137.5%",
+        "type": "lineHeights",
+        "description": "[leading-snug] (1.375 / 137.5%)"
+      },
+      "normal": {
+        "value": "150%",
+        "type": "lineHeights",
+        "description": "[leading-normal] (1.5 / 150%)"
+      },
+      "relaxed": {
+        "value": "162.5%",
+        "type": "lineHeights",
+        "description": "[leading-relaxed] (1.625 / 162.5%)"
+      },
+      "loose": {
+        "value": "200%",
+        "type": "lineHeights",
+        "description": "[leading-loose] (2 / 200%)"
+      }
+    },
+    "color": {
+      "tailwind": {
+        "slate": {
+          "50": {
+            "value": "#f8fafc",
+            "type": "color",
+            "description": "Tailwind Slate 50\n#F8FAFC"
+          },
+          "100": {
+            "value": "#f1f5f9",
+            "type": "color",
+            "description": "Tailwind Slate 100\n#F1F5F9"
+          },
+          "200": {
+            "value": "#e2e8f0",
+            "type": "color",
+            "description": "Tailwind Slate 200\n#E2E8F0"
+          },
+          "300": {
+            "value": "#cbd5e1",
+            "type": "color",
+            "description": "Tailwind Slate 300\n#CBD5E1"
+          },
+          "400": {
+            "value": "#94a3b8",
+            "type": "color",
+            "description": "Tailwind Slate 400\n#94A3B8"
+          },
+          "500": {
+            "value": "#64748b",
+            "type": "color",
+            "description": "Tailwind Slate 500\n#64748B"
+          },
+          "600": {
+            "value": "#475569",
+            "type": "color",
+            "description": "Tailwind Slate 600\n#475569"
+          },
+          "700": {
+            "value": "#334155",
+            "type": "color",
+            "description": "Tailwind Slate 700\n#334155"
+          },
+          "800": {
+            "value": "#1e293b",
+            "type": "color",
+            "description": "Tailwind Slate 800\n#1E293B"
+          },
+          "900": {
+            "value": "#0f172a",
+            "type": "color",
+            "description": "Tailwind Slate 900\n#0F172A"
+          }
+        },
+        "gray": {
+          "50": {
+            "value": "#f9fafb",
+            "type": "color",
+            "description": "Tailwind Gray 50"
+          },
+          "100": {
+            "value": "#f3f4f6",
+            "type": "color",
+            "description": "Tailwind Gray 100"
+          },
+          "200": {
+            "value": "#e5e7eb",
+            "type": "color",
+            "description": "Tailwind Gray 200"
+          },
+          "300": {
+            "value": "#d1d5db",
+            "type": "color",
+            "description": "Tailwind Gray 300"
+          },
+          "400": {
+            "value": "#9ca3af",
+            "type": "color",
+            "description": "Tailwind Gray 400"
+          },
+          "500": {
+            "value": "#6b7280",
+            "type": "color",
+            "description": "Tailwind Gray 500"
+          },
+          "600": {
+            "value": "#4b5563",
+            "type": "color",
+            "description": "Tailwind Gray 600"
+          },
+          "700": {
+            "value": "#374151",
+            "type": "color",
+            "description": "Tailwind Gray 700"
+          },
+          "800": {
+            "value": "#1f2937",
+            "type": "color",
+            "description": "Tailwind Gray 800"
+          },
+          "900": {
+            "value": "#111827",
+            "type": "color",
+            "description": "Tailwind Gray 900"
+          }
+        },
+        "zinc": {
+          "50": {
+            "value": "#fafafa",
+            "type": "color",
+            "description": "Tailwind Zinc 50"
+          },
+          "100": {
+            "value": "#f4f4f5",
+            "type": "color",
+            "description": "Tailwind Zinc 100"
+          },
+          "200": {
+            "value": "#e4e4e7",
+            "type": "color",
+            "description": "Tailwind Zinc 200"
+          },
+          "300": {
+            "value": "#d4d4d8",
+            "type": "color",
+            "description": "Tailwind Zinc 300"
+          },
+          "400": {
+            "value": "#a1a1aa",
+            "type": "color",
+            "description": "Tailwind Zinc 400"
+          },
+          "500": {
+            "value": "#71717a",
+            "type": "color",
+            "description": "Tailwind Zinc 500"
+          },
+          "600": {
+            "value": "#52525b",
+            "type": "color",
+            "description": "Tailwind Zinc 600"
+          },
+          "700": {
+            "value": "#3f3f46",
+            "type": "color",
+            "description": "Tailwind Zinc 700"
+          },
+          "800": {
+            "value": "#27272a",
+            "type": "color",
+            "description": "Tailwind Zinc 800"
+          },
+          "900": {
+            "value": "#18181b",
+            "type": "color",
+            "description": "Tailwind Zinc 900"
+          }
+        },
+        "neutral": {
+          "50": {
+            "value": "#fafafa",
+            "type": "color",
+            "description": "Tailwind Neutral 50"
+          },
+          "100": {
+            "value": "#f5f5f5",
+            "type": "color",
+            "description": "Tailwind Neutral 100"
+          },
+          "200": {
+            "value": "#e5e5e5",
+            "type": "color",
+            "description": "Tailwind Neutral 200"
+          },
+          "300": {
+            "value": "#d4d4d4",
+            "type": "color",
+            "description": "Tailwind Neutral 300"
+          },
+          "400": {
+            "value": "#a3a3a3",
+            "type": "color",
+            "description": "Tailwind Neutral 400"
+          },
+          "500": {
+            "value": "#737373",
+            "type": "color",
+            "description": "Tailwind Neutral 500"
+          },
+          "600": {
+            "value": "#525252",
+            "type": "color",
+            "description": "Tailwind Neutral 600"
+          },
+          "700": {
+            "value": "#404040",
+            "type": "color",
+            "description": "Tailwind Neutral 700"
+          },
+          "800": {
+            "value": "#262626",
+            "type": "color",
+            "description": "Tailwind Neutral 800"
+          },
+          "900": {
+            "value": "#171717",
+            "type": "color",
+            "description": "Tailwind Neutral 900"
+          }
+        },
+        "stone": {
+          "50": {
+            "value": "#fafaf9",
+            "type": "color",
+            "description": "Tailwind Stone 50\n#FAFAF9"
+          },
+          "100": {
+            "value": "#f5f5f4",
+            "type": "color",
+            "description": "Tailwind Stone 100\n#F5F5F4"
+          },
+          "200": {
+            "value": "#e7e5e4",
+            "type": "color",
+            "description": "Tailwind Stone 200\n#E7E5E4"
+          },
+          "300": {
+            "value": "#d6d3d1",
+            "type": "color",
+            "description": "Tailwind Stone 300\n#D6D3D1"
+          },
+          "400": {
+            "value": "#a8a29e",
+            "type": "color",
+            "description": "Tailwind Stone 400\n#A8A29E"
+          },
+          "500": {
+            "value": "#78716c",
+            "type": "color",
+            "description": "Tailwind Stone 500\n#78716C"
+          },
+          "600": {
+            "value": "#57534e",
+            "type": "color",
+            "description": "Tailwind Stone 600\n#57534E"
+          },
+          "700": {
+            "value": "#44403c",
+            "type": "color",
+            "description": "Tailwind Stone 700\n#44403C"
+          },
+          "800": {
+            "value": "#292524",
+            "type": "color",
+            "description": "Tailwind Stone 800\n#292524"
+          },
+          "900": {
+            "value": "#1c1917",
+            "type": "color",
+            "description": "Tailwind Stone 900\n#1C1917"
+          }
+        },
+        "red": {
+          "50": {
+            "value": "#fef2f2",
+            "type": "color",
+            "description": "Tailwind Red 50\n#FEF2F2"
+          },
+          "100": {
+            "value": "#fee2e2",
+            "type": "color",
+            "description": "Tailwind Red 100\n#FEE2E2"
+          },
+          "200": {
+            "value": "#fecaca",
+            "type": "color",
+            "description": "Tailwind Red 200\n#FECACA"
+          },
+          "300": {
+            "value": "#fca5a5",
+            "type": "color",
+            "description": "Tailwind Red 300\n#FCA5A5"
+          },
+          "400": {
+            "value": "#f87171",
+            "type": "color",
+            "description": "Tailwind Red 400\n#F87171"
+          },
+          "500": {
+            "value": "#ef4444",
+            "type": "color",
+            "description": "Tailwind Red 500\n#EF4444"
+          },
+          "600": {
+            "value": "#dc2626",
+            "type": "color",
+            "description": "Tailwind Red 600\n#DC2626"
+          },
+          "700": {
+            "value": "#b91c1c",
+            "type": "color",
+            "description": "Tailwind Red 700\n#B91C1C"
+          },
+          "800": {
+            "value": "#991b1b",
+            "type": "color",
+            "description": "Tailwind Red 800\n#991B1B"
+          },
+          "900": {
+            "value": "#7f1d1d",
+            "type": "color",
+            "description": "Tailwind Red 900\n#7F1D1D"
+          }
+        },
+        "orange": {
+          "50": {
+            "value": "#fff7ed",
+            "type": "color",
+            "description": "Tailwind Orange 50\n#FFF7ED"
+          },
+          "100": {
+            "value": "#ffedd5",
+            "type": "color",
+            "description": "Tailwind Orange 100\n#FFEDD5"
+          },
+          "200": {
+            "value": "#fed7aa",
+            "type": "color",
+            "description": "Tailwind Orange 200\n#FED7AA"
+          },
+          "300": {
+            "value": "#fdba74",
+            "type": "color",
+            "description": "Tailwind Orange 300\n#FDBA74"
+          },
+          "400": {
+            "value": "#fb923c",
+            "type": "color",
+            "description": "Tailwind Orange 400\n#FB923C"
+          },
+          "500": {
+            "value": "#f97316",
+            "type": "color",
+            "description": "Tailwind Orange 500\n#F97316"
+          },
+          "600": {
+            "value": "#ea580c",
+            "type": "color",
+            "description": "Tailwind Orange 600\n#EA580C"
+          },
+          "700": {
+            "value": "#c2410c",
+            "type": "color",
+            "description": "Tailwind Orange 700\n#C2410C"
+          },
+          "800": {
+            "value": "#9a3412",
+            "type": "color",
+            "description": "Tailwind Orange 800\n#9A3412"
+          },
+          "900": {
+            "value": "#7c2d12",
+            "type": "color",
+            "description": "Tailwind Orange 900\n#7C2D12"
+          }
+        },
+        "amber": {
+          "50": {
+            "value": "#fffbeb",
+            "type": "color",
+            "description": "Tailwind Amber 50\n#FFFBEB"
+          },
+          "100": {
+            "value": "#fef3c7",
+            "type": "color",
+            "description": "Tailwind Amber 100\n#FEF3C7"
+          },
+          "200": {
+            "value": "#fde68a",
+            "type": "color",
+            "description": "Tailwind Amber 200\n#FDE68A"
+          },
+          "300": {
+            "value": "#fcd34d",
+            "type": "color",
+            "description": "Tailwind Amber 300\n#FCD34D"
+          },
+          "400": {
+            "value": "#fbbf24",
+            "type": "color",
+            "description": "Tailwind Amber 400\n#FBBF24"
+          },
+          "500": {
+            "value": "#f59e0b",
+            "type": "color",
+            "description": "Tailwind Amber 500\n#F59E0B"
+          },
+          "600": {
+            "value": "#d97706",
+            "type": "color",
+            "description": "Tailwind Amber 600\n#D97706"
+          },
+          "700": {
+            "value": "#b45309",
+            "type": "color",
+            "description": "Tailwind Amber 700\n#b45309"
+          },
+          "800": {
+            "value": "#92400e",
+            "type": "color",
+            "description": "Tailwind Amber 800\n#92400E"
+          },
+          "900": {
+            "value": "#78350f",
+            "type": "color",
+            "description": "Tailwind Amber 900\n#78350F"
+          }
+        },
+        "yellow": {
+          "50": {
+            "value": "#fefce8",
+            "type": "color",
+            "description": "Tailwind Yellow 50\n#FEFCE8"
+          },
+          "100": {
+            "value": "#fef9c3",
+            "type": "color",
+            "description": "Tailwind Yellow 100\n#FEF9C3"
+          },
+          "200": {
+            "value": "#fef08a",
+            "type": "color",
+            "description": "Tailwind Yellow 200\n#FEF08A"
+          },
+          "300": {
+            "value": "#fde047",
+            "type": "color",
+            "description": "Tailwind Yellow 300\n#FDE047"
+          },
+          "400": {
+            "value": "#facc15",
+            "type": "color",
+            "description": "Tailwind Yellow 400\n#FACC15"
+          },
+          "500": {
+            "value": "#eab308",
+            "type": "color",
+            "description": "Tailwind Yellow 500\n#EAB308"
+          },
+          "600": {
+            "value": "#ca8a04",
+            "type": "color",
+            "description": "Tailwind Yellow 600\n#CA8A04"
+          },
+          "700": {
+            "value": "#a16207",
+            "type": "color",
+            "description": "Tailwind Yellow 700\n#A16207"
+          },
+          "800": {
+            "value": "#854d0e",
+            "type": "color",
+            "description": "Tailwind Yellow 800\n#854D0E"
+          },
+          "900": {
+            "value": "#713f12",
+            "type": "color",
+            "description": "Tailwind Yellow 900\n#713F12"
+          }
+        },
+        "lime": {
+          "50": {
+            "value": "#f7fee7",
+            "type": "color",
+            "description": "Tailwind Lime 50\n#F7FEE7"
+          },
+          "100": {
+            "value": "#ecfccb",
+            "type": "color",
+            "description": "Tailwind Lime 100\n#ECFCCB"
+          },
+          "200": {
+            "value": "#d9f99d",
+            "type": "color",
+            "description": "Tailwind Lime 200\n#D9F99D"
+          },
+          "300": {
+            "value": "#bef264",
+            "type": "color",
+            "description": "Tailwind Lime 300\n#BEF264"
+          },
+          "400": {
+            "value": "#a3e635",
+            "type": "color",
+            "description": "Tailwind Lime 400\n#A3E635"
+          },
+          "500": {
+            "value": "#84cc16",
+            "type": "color",
+            "description": "Tailwind Lime 500\n#84CC16"
+          },
+          "600": {
+            "value": "#65a30d",
+            "type": "color",
+            "description": "Tailwind Lime 600\n#65A30D"
+          },
+          "700": {
+            "value": "#4d7c0f",
+            "type": "color",
+            "description": "Tailwind Lime 700\n#4D7C0F"
+          },
+          "800": {
+            "value": "#3f6212",
+            "type": "color",
+            "description": "Tailwind Lime 800\n#3F6212"
+          },
+          "900": {
+            "value": "#365314",
+            "type": "color",
+            "description": "Tailwind Lime 900\n#365314"
+          }
+        },
+        "green": {
+          "50": {
+            "value": "#f0fdf4",
+            "type": "color",
+            "description": "Tailwind Green 50\n#F0FDF4"
+          },
+          "100": {
+            "value": "#dcfce7",
+            "type": "color",
+            "description": "Tailwind Green 100\n#DCFCE7"
+          },
+          "200": {
+            "value": "#bbf7d0",
+            "type": "color",
+            "description": "Tailwind Green 200\n#BBF7D0"
+          },
+          "300": {
+            "value": "#86efac",
+            "type": "color",
+            "description": "Tailwind Green 300\n#86EFAC"
+          },
+          "400": {
+            "value": "#4ade80",
+            "type": "color",
+            "description": "Tailwind Green 400\n#4ADE80"
+          },
+          "500": {
+            "value": "#22c55e",
+            "type": "color",
+            "description": "Tailwind Green 500\n#22C55E"
+          },
+          "600": {
+            "value": "#16a34a",
+            "type": "color",
+            "description": "Tailwind Green 600\n#16A34A"
+          },
+          "700": {
+            "value": "#15803d",
+            "type": "color",
+            "description": "Tailwind Green 700\n#15803D"
+          },
+          "800": {
+            "value": "#166534",
+            "type": "color",
+            "description": "Tailwind Green 800\n#166534"
+          },
+          "900": {
+            "value": "#14532d",
+            "type": "color",
+            "description": "Tailwind Green 900\n#14532D"
+          }
+        },
+        "emerald": {
+          "50": {
+            "value": "#ecfdf5",
+            "type": "color",
+            "description": "Tailwind Emerald 50\n#ECFDF5"
+          },
+          "100": {
+            "value": "#d1fae5",
+            "type": "color",
+            "description": "Tailwind Emerald 100\n#D1FAE5"
+          },
+          "200": {
+            "value": "#a7f3d0",
+            "type": "color",
+            "description": "Tailwind Emerald 200\n#A7F3D0"
+          },
+          "300": {
+            "value": "#6ee7b7",
+            "type": "color",
+            "description": "Tailwind Emerald 300\n#6EE7B7"
+          },
+          "400": {
+            "value": "#34d399",
+            "type": "color",
+            "description": "Tailwind Emerald 400\n#34D399"
+          },
+          "500": {
+            "value": "#10b981",
+            "type": "color",
+            "description": "Tailwind Emerald 500\n#10B981"
+          },
+          "600": {
+            "value": "#059669",
+            "type": "color",
+            "description": "Tailwind Emerald 600\n#059669"
+          },
+          "700": {
+            "value": "#047857",
+            "type": "color",
+            "description": "Tailwind Emerald 700\n#047857"
+          },
+          "800": {
+            "value": "#065f46",
+            "type": "color",
+            "description": "Tailwind Emerald 800\n#065F46"
+          },
+          "900": {
+            "value": "#064e3b",
+            "type": "color",
+            "description": "Tailwind Emerald 900\n#064E3B"
+          }
+        },
+        "teal": {
+          "50": {
+            "value": "#f0fdfa",
+            "type": "color",
+            "description": "Tailwind Teal 50\n#F0FDFA"
+          },
+          "100": {
+            "value": "#ccfbf1",
+            "type": "color",
+            "description": "Tailwind Teal 100\n#CCFBF1"
+          },
+          "200": {
+            "value": "#99f6e4",
+            "type": "color",
+            "description": "Tailwind Teal 200\n#99F6E4"
+          },
+          "300": {
+            "value": "#5eead4",
+            "type": "color",
+            "description": "Tailwind Teal 300\n#5EEAD4"
+          },
+          "400": {
+            "value": "#2dd4bf",
+            "type": "color",
+            "description": "Tailwind Teal 400\n#2DD4BF"
+          },
+          "500": {
+            "value": "#14b8a6",
+            "type": "color",
+            "description": "Tailwind Teal 500\n#14B8A6"
+          },
+          "600": {
+            "value": "#0d9488",
+            "type": "color",
+            "description": "Tailwind Teal 600\n#0D9488"
+          },
+          "700": {
+            "value": "#0f766e",
+            "type": "color",
+            "description": "Tailwind Teal 700\n#0F766E"
+          },
+          "800": {
+            "value": "#115e59",
+            "type": "color",
+            "description": "Tailwind Teal 800\n#115E59"
+          },
+          "900": {
+            "value": "#134e4a",
+            "type": "color",
+            "description": "Tailwind Teal 900\n#134E4A"
+          }
+        },
+        "cyan": {
+          "50": {
+            "value": "#ecfeff",
+            "type": "color",
+            "description": "Tailwind Cyan 50\n#ECFEFF"
+          },
+          "100": {
+            "value": "#cffafe",
+            "type": "color",
+            "description": "Tailwind Cyan 100\n#CFFAFE"
+          },
+          "200": {
+            "value": "#a5f3fc",
+            "type": "color",
+            "description": "Tailwind Cyan 200\n#A5F3FC"
+          },
+          "300": {
+            "value": "#67e8f9",
+            "type": "color",
+            "description": "Tailwind Cyan 300\n#67E8F9"
+          },
+          "400": {
+            "value": "#22d3ee",
+            "type": "color",
+            "description": "Tailwind Cyan 400\n#22D3EE"
+          },
+          "500": {
+            "value": "#06b6d4",
+            "type": "color",
+            "description": "Tailwind Cyan 500\n#06B6D4"
+          },
+          "600": {
+            "value": "#0891b2",
+            "type": "color",
+            "description": "Tailwind Cyan 600\n#0891B2"
+          },
+          "700": {
+            "value": "#0e7490",
+            "type": "color",
+            "description": "Tailwind Cyan 700\n#0E7490"
+          },
+          "800": {
+            "value": "#155e75",
+            "type": "color",
+            "description": "Tailwind Cyan 800\n#155E75"
+          },
+          "900": {
+            "value": "#164e63",
+            "type": "color",
+            "description": "Tailwind Cyan 900\n#164E63"
+          }
+        },
+        "sky": {
+          "50": {
+            "value": "#f0f9ff",
+            "type": "color",
+            "description": "Tailwind Sky 50\n#F0F9FF"
+          },
+          "100": {
+            "value": "#e0f2fe",
+            "type": "color",
+            "description": "Tailwind Sky 100\n#E0F2FE"
+          },
+          "200": {
+            "value": "#bae6fd",
+            "type": "color",
+            "description": "Tailwind Sky 200\n#BAE6FD"
+          },
+          "300": {
+            "value": "#7dd3fc",
+            "type": "color",
+            "description": "Tailwind Sky 300\n#7DD3FC"
+          },
+          "400": {
+            "value": "#38bdf8",
+            "type": "color",
+            "description": "Tailwind Sky 400\n#38BDF8"
+          },
+          "500": {
+            "value": "#0ea5e9",
+            "type": "color",
+            "description": "Tailwind Sky 500\n#0EA5E9"
+          },
+          "600": {
+            "value": "#0284c7",
+            "type": "color",
+            "description": "Tailwind Sky 600\n#0284C7"
+          },
+          "700": {
+            "value": "#0369a1",
+            "type": "color",
+            "description": "Tailwind Sky 700\n#0369A1"
+          },
+          "800": {
+            "value": "#075985",
+            "type": "color",
+            "description": "Tailwind Sky 800\n#075985"
+          },
+          "900": {
+            "value": "#0c4a6e",
+            "type": "color",
+            "description": "Tailwind Sky 900\n#0C4A6E"
+          }
+        },
+        "blue": {
+          "50": {
+            "value": "#eff6ff",
+            "type": "color",
+            "description": "Tailwind Blue 50\n#EFF6FF"
+          },
+          "100": {
+            "value": "#dbeafe",
+            "type": "color",
+            "description": "Tailwind Blue 100\n#DBEAFE"
+          },
+          "200": {
+            "value": "#bfdbfe",
+            "type": "color",
+            "description": "Tailwind Blue 200\n#BFDBFE"
+          },
+          "300": {
+            "value": "#93c5fd",
+            "type": "color",
+            "description": "Tailwind Blue 300\n#93C5FD"
+          },
+          "400": {
+            "value": "#60a5fa",
+            "type": "color",
+            "description": "Tailwind Blue 400\n#60A5FA"
+          },
+          "500": {
+            "value": "#3b82f6",
+            "type": "color",
+            "description": "Tailwind Blue 500\n#3B82F6"
+          },
+          "600": {
+            "value": "#2563eb",
+            "type": "color",
+            "description": "Tailwind Blue 600\n#2563EB"
+          },
+          "700": {
+            "value": "#1d4ed8",
+            "type": "color",
+            "description": "Tailwind Blue 700\n#1D4ED8"
+          },
+          "800": {
+            "value": "#1e40af",
+            "type": "color",
+            "description": "Tailwind Blue 800\n#1E40AF"
+          },
+          "900": {
+            "value": "#1e3a8a",
+            "type": "color",
+            "description": "Tailwind Blue 900\n#1E3A8A"
+          }
+        },
+        "indigo": {
+          "50": {
+            "value": "#eef2ff",
+            "type": "color",
+            "description": "Tailwind Indigo 50\n#EEF2FF"
+          },
+          "100": {
+            "value": "#e0e7ff",
+            "type": "color",
+            "description": "Tailwind Indigo 100\n#E0E7FF"
+          },
+          "200": {
+            "value": "#c7d2fe",
+            "type": "color",
+            "description": "Tailwind Indigo 200\n#C7D2FE"
+          },
+          "300": {
+            "value": "#a5b4fc",
+            "type": "color",
+            "description": "Tailwind Indigo 300\n#A5B4FC"
+          },
+          "400": {
+            "value": "#818cf8",
+            "type": "color",
+            "description": "Tailwind Indigo 400\n#818CF8"
+          },
+          "500": {
+            "value": "#6366f1",
+            "type": "color",
+            "description": "Tailwind Indigo 500\n#6366F1"
+          },
+          "600": {
+            "value": "#4f46e5",
+            "type": "color",
+            "description": "Tailwind Indigo 600\n#4F46E5"
+          },
+          "700": {
+            "value": "#4338ca",
+            "type": "color",
+            "description": "Tailwind Indigo 700\n#4338CA"
+          },
+          "800": {
+            "value": "#3730a3",
+            "type": "color",
+            "description": "Tailwind Indigo 800\n#3730A3"
+          },
+          "900": {
+            "value": "#312e81",
+            "type": "color",
+            "description": "Tailwind Indigo 900\n#312E81"
+          }
+        },
+        "violet": {
+          "50": {
+            "value": "#f5f3ff",
+            "type": "color",
+            "description": "Tailwind Violet 50\n#F5F3FF"
+          },
+          "100": {
+            "value": "#ede9fe",
+            "type": "color",
+            "description": "Tailwind Violet 100\n#EDE9FE"
+          },
+          "200": {
+            "value": "#ddd6fe",
+            "type": "color",
+            "description": "Tailwind Violet 200\n#DDD6FE"
+          },
+          "300": {
+            "value": "#c4b5fd",
+            "type": "color",
+            "description": "Tailwind Violet 300\n#C4B5FD"
+          },
+          "400": {
+            "value": "#a78bfa",
+            "type": "color",
+            "description": "Tailwind Violet 400\n#A78BFA"
+          },
+          "500": {
+            "value": "#8b5cf6",
+            "type": "color",
+            "description": "Tailwind Violet 500\n#8B5CF6"
+          },
+          "600": {
+            "value": "#7c3aed",
+            "type": "color",
+            "description": "Tailwind Violet 600\n#7C3AED"
+          },
+          "700": {
+            "value": "#6d28d9",
+            "type": "color",
+            "description": "Tailwind Violet 700\n#6D28D9"
+          },
+          "800": {
+            "value": "#5b21b6",
+            "type": "color",
+            "description": "Tailwind Violet 800\n#5B21B6"
+          },
+          "900": {
+            "value": "#4c1d95",
+            "type": "color",
+            "description": "Tailwind Violet 900\n#4C1D95"
+          }
+        },
+        "purple": {
+          "50": {
+            "value": "#faf5ff",
+            "type": "color",
+            "description": "Tailwind Purple 50\n#FAF5FF"
+          },
+          "100": {
+            "value": "#f3e8ff",
+            "type": "color",
+            "description": "Tailwind Purple 100\n#F3E8FF"
+          },
+          "200": {
+            "value": "#e9d5ff",
+            "type": "color",
+            "description": "Tailwind Purple 200\n#E9D5FF"
+          },
+          "300": {
+            "value": "#d8b4fe",
+            "type": "color",
+            "description": "Tailwind Purple 300\n#D8B4FE"
+          },
+          "400": {
+            "value": "#c084fc",
+            "type": "color",
+            "description": "Tailwind Purple 400\n#C084FC"
+          },
+          "500": {
+            "value": "#a855f7",
+            "type": "color",
+            "description": "Tailwind Purple 500\n#A855F7"
+          },
+          "600": {
+            "value": "#9333ea",
+            "type": "color",
+            "description": "Tailwind Purple 600\n#9333EA"
+          },
+          "700": {
+            "value": "#7e22ce",
+            "type": "color",
+            "description": "Tailwind Purple 700\n#7E22CE"
+          },
+          "800": {
+            "value": "#6b21a8",
+            "type": "color",
+            "description": "Tailwind Purple 800\n#6B21A8"
+          },
+          "900": {
+            "value": "#581c87",
+            "type": "color",
+            "description": "Tailwind Purple 900\n#581C87"
+          }
+        },
+        "fuchsia": {
+          "50": {
+            "value": "#fdf4ff",
+            "type": "color",
+            "description": "Tailwind Fuchsia 50\n#FDF4FF"
+          },
+          "100": {
+            "value": "#fae8ff",
+            "type": "color",
+            "description": "Tailwind Fuchsia 100\n#FAE8FF"
+          },
+          "200": {
+            "value": "#f5d0fe",
+            "type": "color",
+            "description": "Tailwind Fuchsia 200\n#F5D0FE"
+          },
+          "300": {
+            "value": "#f0abfc",
+            "type": "color",
+            "description": "Tailwind Fuchsia 300\n#F0ABFC"
+          },
+          "400": {
+            "value": "#e879f9",
+            "type": "color",
+            "description": "Tailwind Fuchsia 400\n#E879F9"
+          },
+          "500": {
+            "value": "#d946ef",
+            "type": "color",
+            "description": "Tailwind Fuchsia 500\n#D946EF"
+          },
+          "600": {
+            "value": "#c026d3",
+            "type": "color",
+            "description": "Tailwind Fuchsia 600\n#C026D3"
+          },
+          "700": {
+            "value": "#a21caf",
+            "type": "color",
+            "description": "Tailwind Fuchsia 700\n#A21CAF"
+          },
+          "800": {
+            "value": "#86198f",
+            "type": "color",
+            "description": "Tailwind Fuchsia 800\n#86198F"
+          },
+          "900": {
+            "value": "#701a75",
+            "type": "color",
+            "description": "Tailwind Fuchsia 900\n#701A75"
+          }
+        },
+        "pink": {
+          "50": {
+            "value": "#fdf2f8",
+            "type": "color",
+            "description": "Tailwind Pink 50\n#FDF2F8"
+          },
+          "100": {
+            "value": "#fce7f3",
+            "type": "color",
+            "description": "Tailwind Pink 100\n#FCE7F3"
+          },
+          "200": {
+            "value": "#fbcfe8",
+            "type": "color",
+            "description": "Tailwind Pink 200\n#FBCFE8"
+          },
+          "300": {
+            "value": "#f9a8d4",
+            "type": "color",
+            "description": "Tailwind Pink 300\n#F9A8D4"
+          },
+          "400": {
+            "value": "#f472b6",
+            "type": "color",
+            "description": "Tailwind Pink 400\n#F472B6"
+          },
+          "500": {
+            "value": "#ec4899",
+            "type": "color",
+            "description": "Tailwind Pink 500\n#EC4899"
+          },
+          "600": {
+            "value": "#db2777",
+            "type": "color",
+            "description": "Tailwind Pink 600\n#DB2777"
+          },
+          "700": {
+            "value": "#be185d",
+            "type": "color",
+            "description": "Tailwind Pink 700\n#BE185D"
+          },
+          "800": {
+            "value": "#9d174d",
+            "type": "color",
+            "description": "Tailwind Pink 800\n#9D174D"
+          },
+          "900": {
+            "value": "#831843",
+            "type": "color",
+            "description": "Tailwind Pink 900\n#831843"
+          }
+        },
+        "rose": {
+          "50": {
+            "value": "#fff1f2",
+            "type": "color",
+            "description": "Tailwind Rose 50\n#FFF1F2"
+          },
+          "100": {
+            "value": "#ffe4e6",
+            "type": "color",
+            "description": "Tailwind Rose 100\n#FFE4E6"
+          },
+          "200": {
+            "value": "#fecdd3",
+            "type": "color",
+            "description": "Tailwind Rose 200\n#FECDD3"
+          },
+          "300": {
+            "value": "#fda4af",
+            "type": "color",
+            "description": "Tailwind Rose 300\n#FDA4AF"
+          },
+          "400": {
+            "value": "#fb7185",
+            "type": "color",
+            "description": "Tailwind Rose 400\n#FB7185"
+          },
+          "500": {
+            "value": "#f43f5e",
+            "type": "color",
+            "description": "Tailwind Rose 500\n#F43F5E"
+          },
+          "600": {
+            "value": "#e11d48",
+            "type": "color",
+            "description": "Tailwind Rose 600\n#E11D48"
+          },
+          "700": {
+            "value": "#be123c",
+            "type": "color",
+            "description": "Tailwind Rose 700\n#BE123C"
+          },
+          "800": {
+            "value": "#9f1239",
+            "type": "color",
+            "description": "Tailwind Rose 800\n#9F1239"
+          },
+          "900": {
+            "value": "#881337",
+            "type": "color",
+            "description": "Tailwind Rose 900\n#881337"
+          }
+        }
+      }
+    },
+    "fontSizes": {
+      "xs": {
+        "value": "12",
+        "type": "fontSizes",
+        "description": "[text-xs] (0.75rem / 12px)"
+      },
+      "sm": {
+        "value": "14",
+        "type": "fontSizes",
+        "description": "[text-sm] (0.875rem / 14px)"
+      },
+      "base": {
+        "value": "16",
+        "type": "fontSizes",
+        "description": "[text-base] (1rem / 16px)"
+      },
+      "lg": {
+        "value": "18",
+        "type": "fontSizes",
+        "description": "[text-lg] (1.125rem / 18px)"
+      },
+      "xl": {
+        "value": "20",
+        "type": "fontSizes",
+        "description": "[text-xl] (1.25rem / 20px)"
+      },
+      "2xl": {
+        "value": "24",
+        "type": "fontSizes",
+        "description": "[text-2xl] (1.5rem / 24px)"
+      },
+      "3xl": {
+        "value": "30",
+        "type": "fontSizes",
+        "description": "[text-3xl] (1.875rem / 30px)"
+      },
+      "4xl": {
+        "value": "36",
+        "type": "fontSizes",
+        "description": "[text-4xl] (2.25rem / 36px)"
+      },
+      "5xl": {
+        "value": "48",
+        "type": "fontSizes",
+        "description": "[text-5xl] (3rem / 48px)"
+      },
+      "6xl": {
+        "value": "60",
+        "type": "fontSizes",
+        "description": "[text-6xl] (3.75rem / 60px)"
+      },
+      "7xl": {
+        "value": "72",
+        "type": "fontSizes",
+        "description": "[text-7xl] (4.5rem / 72px)"
+      },
+      "8xl": {
+        "value": "96",
+        "type": "fontSizes",
+        "description": "[text-8xl] (6rem / 96px)"
+      },
+      "9xl": {
+        "value": "128",
+        "type": "fontSizes",
+        "description": "[text-9xl] (8rem / 128px)"
+      }
+    },
+    "fontFamilies": {
+      "roboto": {
+        "sans": {
+          "value": "Roboto",
+          "type": "fontFamilies",
+          "description": "Roboto"
+        },
+        "serif": {
+          "value": "Roboto Serif",
+          "type": "fontFamilies",
+          "description": "Roboto Serif"
+        },
+        "mono": {
+          "value": "Roboto Mono",
+          "type": "fontFamilies",
+          "description": "Roboto Mono"
+        }
+      }
+    },
+    "fontWeights": {
+      "thin": {
+        "normal": {
+          "value": "Thin",
+          "type": "fontWeights",
+          "description": "[text-thin not-italic] (100 / normal)"
+        },
+        "italic": {
+          "value": "Thin Italic",
+          "type": "fontWeights",
+          "description": "[text-thin italic] (100 / italic)"
+        }
+      },
+      "extralight": {
+        "normal": {
+          "value": "ExtraLight",
+          "type": "fontWeights",
+          "description": "[text-extralight not-italic] (200 / normal)"
+        },
+        "italic": {
+          "value": "ExtraLight Italic",
+          "type": "fontWeights",
+          "description": "[text-extralight italic] (200 / italic)"
+        }
+      },
+      "light": {
+        "normal": {
+          "value": "Light",
+          "type": "fontWeights",
+          "description": "[text-light not-italic] (300 / normal)"
+        },
+        "italic": {
+          "value": "Light Italic",
+          "type": "fontWeights",
+          "description": "[text-light italic] (300 / italic)"
+        }
+      },
+      "regular": {
+        "normal": {
+          "value": "Regular",
+          "type": "fontWeights",
+          "description": "[text-regular not-italic] (400 / normal)"
+        },
+        "italic": {
+          "value": "Italic",
+          "type": "fontWeights",
+          "description": "[text-regular italic] (400 / italic)"
+        }
+      },
+      "medium": {
+        "normal": {
+          "value": "Medium",
+          "type": "fontWeights",
+          "description": "[text-medium not-italic] (500 / normal)"
+        },
+        "italic": {
+          "value": "Medium Italic",
+          "type": "fontWeights",
+          "description": "[text-medium italic] (500 / italic)"
+        }
+      },
+      "semibold": {
+        "normal": {
+          "value": "SemiBold",
+          "type": "fontWeights",
+          "description": "[text-semibold not-italic] (600 / normal)"
+        },
+        "italic": {
+          "value": "SemiBold Italic",
+          "type": "fontWeights",
+          "description": "[text-semibold italic] (600 / italic)"
+        }
+      },
+      "bold": {
+        "normal": {
+          "value": "Bold",
+          "type": "fontWeights",
+          "description": "[text-bold not-italic] (700 / normal)"
+        },
+        "italic": {
+          "value": "Bold Italic",
+          "type": "fontWeights",
+          "description": "[text-bold italic] (700 / italic)"
+        }
+      },
+      "extrabold": {
+        "normal": {
+          "value": "ExtraBold",
+          "type": "fontWeights",
+          "description": "[text-extrabold not-italic] (800 / normal)"
+        },
+        "italic": {
+          "value": "ExtraBold Italic",
+          "type": "fontWeights",
+          "description": "[text-extrabold italic] (800 / italic)"
+        }
+      },
+      "black": {
+        "normal": {
+          "value": "Black",
+          "type": "fontWeights",
+          "description": "[text-black not-italic] (900 / normal)"
+        },
+        "italic": {
+          "value": "Black Italic",
+          "type": "fontWeights",
+          "description": "[text-black italic] (900 / italic)"
+        }
+      }
+    },
+    "typography": {
+      "sans": {
+        "thin": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-xs] (Roboto 100 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-sm] (Roboto 100 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-base] (Roboto 100 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-lg] (Roboto 100 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-xl] (Roboto 100 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-2xl] (Roboto 100 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-3xl] (Roboto 100 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-4xl] (Roboto 100 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-5xl] (Roboto 100 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-6xl] (Roboto 100 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-7xl] (Roboto 100 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-8xl] (Roboto 100 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin not-italic text-9xl] (Roboto 100 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-xs] (Roboto 100 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-sm] (Roboto 100 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-base] (Roboto 100 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-lg] (Roboto 100 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-xl] (Roboto 100 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-2xl] (Roboto 100 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-3xl] (Roboto 100 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-4xl] (Roboto 100 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-5xl] (Roboto 100 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-6xl] (Roboto 100 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-7xl] (Roboto 100 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-8xl] (Roboto 100 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-thin italic text-9xl] (Roboto 100 italic 128/100%)"
+            }
+          }
+        },
+        "extralight": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-xs] (Roboto 200 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-sm] (Roboto 200 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-base] (Roboto 200 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-lg] (Roboto 200 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-xl] (Roboto 200 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-2xl] (Roboto 200 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-3xl] (Roboto 200 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-4xl] (Roboto 200 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-5xl] (Roboto 200 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-6xl] (Roboto 200 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-7xl] (Roboto 200 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-8xl] (Roboto 200 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight not-italic text-9xl] (Roboto 200 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-xs] (Roboto 200 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-sm] (Roboto 200 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-base] (Roboto 200 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-lg] (Roboto 200 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-xl] (Roboto 200 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-2xl] (Roboto 200 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-3xl] (Roboto 200 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-4xl] (Roboto 200 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-5xl] (Roboto 200 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-6xl] (Roboto 200 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-7xl] (Roboto 200 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-8xl] (Roboto 200 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extralight italic text-9xl] (Roboto 200 italic 128/100%)"
+            }
+          }
+        },
+        "light": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-xs] (Roboto 300 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-sm] (Roboto 300 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-base] (Roboto 300 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-lg] (Roboto 300 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-xl] (Roboto 300 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-2xl] (Roboto 300 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-3xl] (Roboto 300 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-4xl] (Roboto 300 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-5xl] (Roboto 300 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-6xl] (Roboto 300 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-7xl] (Roboto 300 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-8xl] (Roboto 300 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light not-italic text-9xl] (Roboto 300 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-xs] (Roboto 300 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-sm] (Roboto 300 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-base] (Roboto 300 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-lg] (Roboto 300 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-xl] (Roboto 300 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-2xl] (Roboto 300 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-3xl] (Roboto 300 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-4xl] (Roboto 300 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-5xl] (Roboto 300 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-6xl] (Roboto 300 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-7xl] (Roboto 300 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-8xl] (Roboto 300 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-light italic text-9xl] (Roboto 300 italic 128/100%)"
+            }
+          }
+        },
+        "regular": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-xs] (Roboto 400 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-sm] (Roboto 400 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-base] (Roboto 400 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-lg] (Roboto 400 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-xl] (Roboto 400 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-2xl] (Roboto 400 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-3xl] (Roboto 400 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-4xl] (Roboto 400 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-5xl] (Roboto 400 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-6xl] (Roboto 400 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-7xl] (Roboto 400 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-8xl] (Roboto 400 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular not-italic text-9xl] (Roboto 400 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-xs] (Roboto 400 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-sm] (Roboto 400 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-base] (Roboto 400 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-lg] (Roboto 400 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-xl] (Roboto 400 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-2xl] (Roboto 400 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-3xl] (Roboto 400 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-4xl] (Roboto 400 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-5xl] (Roboto 400 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-6xl] (Roboto 400 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-7xl] (Roboto 400 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-8xl] (Roboto 400 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-regular italic text-9xl] (Roboto 400 italic 128/100%)"
+            }
+          }
+        },
+        "medium": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-xs] (Roboto 500 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-sm] (Roboto 500 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-base] (Roboto 500 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-lg] (Roboto 500 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-xl] (Roboto 500 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-2xl] (Roboto 500 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-3xl] (Roboto 500 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-4xl] (Roboto 500 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-5xl] (Roboto 500 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-6xl] (Roboto 500 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-7xl] (Roboto 500 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-8xl] (Roboto 500 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium not-italic text-9xl] (Roboto 500 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-xs] (Roboto 500 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-sm] (Roboto 500 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-base] (Roboto 500 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-lg] (Roboto 500 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-xl] (Roboto 500 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-2xl] (Roboto 500 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-3xl] (Roboto 500 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-4xl] (Roboto 500 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-5xl] (Roboto 500 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-6xl] (Roboto 500 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-7xl] (Roboto 500 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-8xl] (Roboto 500 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-medium italic text-9xl] (Roboto 500 italic 128/100%)"
+            }
+          }
+        },
+        "semibold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-xs] (Roboto 600 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-sm] (Roboto 600 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-base] (Roboto 600 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-lg] (Roboto 600 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-xl] (Roboto 600 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-2xl] (Roboto 600 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-3xl] (Roboto 600 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-4xl] (Roboto 600 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-5xl] (Roboto 600 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-6xl] (Roboto 600 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-7xl] (Roboto 600 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-8xl] (Roboto 600 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold not-italic text-9xl] (Roboto 600 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-xs] (Roboto 600 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-sm] (Roboto 600 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-base] (Roboto 600 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-lg] (Roboto 600 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-xl] (Roboto 600 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-2xl] (Roboto 600 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-3xl] (Roboto 600 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-4xl] (Roboto 600 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-5xl] (Roboto 600 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-6xl] (Roboto 600 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-7xl] (Roboto 600 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-8xl] (Roboto 600 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-semibold italic text-9xl] (Roboto 600 italic 128/100%)"
+            }
+          }
+        },
+        "bold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-xs] (Roboto 700 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-sm] (Roboto 700 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-base] (Roboto 700 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-lg] (Roboto 700 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-xl] (Roboto 700 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-2xl] (Roboto 700 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-3xl] (Roboto 700 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-4xl] (Roboto 700 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-5xl] (Roboto 700 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-6xl] (Roboto 700 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-7xl] (Roboto 700 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-8xl] (Roboto 700 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold not-italic text-9xl] (Roboto 700 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-xs] (Roboto 700 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-sm] (Roboto 700 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-base] (Roboto 700 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-lg] (Roboto 700 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-xl] (Roboto 700 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-2xl] (Roboto 700 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-3xl] (Roboto 700 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-4xl] (Roboto 700 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-5xl] (Roboto 700 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-6xl] (Roboto 700 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-7xl] (Roboto 700 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-8xl] (Roboto 700 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-bold italic text-9xl] (Roboto 700 italic 128/100%)"
+            }
+          }
+        },
+        "extrabold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-xs] (Roboto 800 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-sm] (Roboto 800 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-base] (Roboto 800 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-lg] (Roboto 800 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-xl] (Roboto 800 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-2xl] (Roboto 800 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-3xl] (Roboto 800 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-4xl] (Roboto 800 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-5xl] (Roboto 800 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-6xl] (Roboto 800 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-7xl] (Roboto 800 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-8xl] (Roboto 800 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold not-italic text-9xl] (Roboto 800 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-xs] (Roboto 800 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-sm] (Roboto 800 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-base] (Roboto 800 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-lg] (Roboto 800 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-xl] (Roboto 800 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-2xl] (Roboto 800 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-3xl] (Roboto 800 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-4xl] (Roboto 800 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-5xl] (Roboto 800 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-6xl] (Roboto 800 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-7xl] (Roboto 800 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-8xl] (Roboto 800 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-extrabold italic text-9xl] (Roboto 800 italic 128/100%)"
+            }
+          }
+        },
+        "black": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-xs] (Roboto 900 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-sm] (Roboto 900 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-base] (Roboto 900 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-lg] (Roboto 900 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-xl] (Roboto 900 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-2xl] (Roboto 900 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-3xl] (Roboto 900 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-4xl] (Roboto 900 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-5xl] (Roboto 900 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-6xl] (Roboto 900 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-7xl] (Roboto 900 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-8xl] (Roboto 900 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black not-italic text-9xl] (Roboto 900 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-xs] (Roboto 900 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-sm] (Roboto 900 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-base] (Roboto 900 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-lg] (Roboto 900 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-xl] (Roboto 900 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-2xl] (Roboto 900 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-3xl] (Roboto 900 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-4xl] (Roboto 900 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-5xl] (Roboto 900 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-6xl] (Roboto 900 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-7xl] (Roboto 900 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-8xl] (Roboto 900 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.sans}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-sans font-black italic text-9xl] (Roboto 900 italic 128/100%)"
+            }
+          }
+        }
+      },
+      "serif": {
+        "thin": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-xs] (Roboto Serif 100 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-sm] (Roboto Serif 100 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-base] (Roboto Serif 100 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-lg] (Roboto Serif 100 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-xl] (Roboto Serif 100 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-2xl] (Roboto Serif 100 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-3xl] (Roboto Serif 100 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-4xl] (Roboto Serif 100 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-5xl] (Roboto Serif 100 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-6xl] (Roboto Serif 100 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-7xl] (Roboto Serif 100 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-8xl] (Roboto Serif 100 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin not-italic text-9xl] (Roboto Serif 100 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-xs] (Roboto Serif 100 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-sm] (Roboto Serif 100 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-base] (Roboto Serif 100 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-lg] (Roboto Serif 100 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-xl] (Roboto Serif 100 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-2xl] (Roboto Serif 100 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-3xl] (Roboto Serif 100 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-4xl] (Roboto Serif 100 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-5xl] (Roboto Serif 100 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-6xl] (Roboto Serif 100 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-7xl] (Roboto Serif 100 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-8xl] (Roboto Serif 100 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-thin italic text-9xl] (Roboto Serif 100 italic 128/100%)"
+            }
+          }
+        },
+        "extralight": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-xs] (Roboto Serif 200 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-sm] (Roboto Serif 200 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-base] (Roboto Serif 200 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-lg] (Roboto Serif 200 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-xl] (Roboto Serif 200 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-2xl] (Roboto Serif 200 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-3xl] (Roboto Serif 200 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-4xl] (Roboto Serif 200 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-5xl] (Roboto Serif 200 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-6xl] (Roboto Serif 200 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-7xl] (Roboto Serif 200 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-8xl] (Roboto Serif 200 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight not-italic text-9xl] (Roboto Serif 200 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-xs] (Roboto Serif 200 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-sm] (Roboto Serif 200 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-base] (Roboto Serif 200 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-lg] (Roboto Serif 200 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-xl] (Roboto Serif 200 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-2xl] (Roboto Serif 200 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-3xl] (Roboto Serif 200 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-4xl] (Roboto Serif 200 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-5xl] (Roboto Serif 200 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-6xl] (Roboto Serif 200 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-7xl] (Roboto Serif 200 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-8xl] (Roboto Serif 200 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extralight italic text-9xl] (Roboto Serif 200 italic 128/100%)"
+            }
+          }
+        },
+        "light": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-xs] (Roboto Serif 300 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-sm] (Roboto Serif 300 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-base] (Roboto Serif 300 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-lg] (Roboto Serif 300 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-xl] (Roboto Serif 300 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-2xl] (Roboto Serif 300 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-3xl] (Roboto Serif 300 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-4xl] (Roboto Serif 300 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-5xl] (Roboto Serif 300 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-6xl] (Roboto Serif 300 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-7xl] (Roboto Serif 300 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-8xl] (Roboto Serif 300 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light not-italic text-9xl] (Roboto Serif 300 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-xs] (Roboto Serif 300 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-sm] (Roboto Serif 300 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-base] (Roboto Serif 300 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-lg] (Roboto Serif 300 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-xl] (Roboto Serif 300 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-2xl] (Roboto Serif 300 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-3xl] (Roboto Serif 300 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-4xl] (Roboto Serif 300 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-5xl] (Roboto Serif 300 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-6xl] (Roboto Serif 300 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-7xl] (Roboto Serif 300 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-8xl] (Roboto Serif 300 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-light italic text-9xl] (Roboto Serif 300 italic 128/100%)"
+            }
+          }
+        },
+        "regular": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-xs] (Roboto Serif 400 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-sm] (Roboto Serif 400 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-base] (Roboto Serif 400 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-lg] (Roboto Serif 400 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-xl] (Roboto Serif 400 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-2xl] (Roboto Serif 400 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-3xl] (Roboto Serif 400 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-4xl] (Roboto Serif 400 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-5xl] (Roboto Serif 400 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-6xl] (Roboto Serif 400 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-7xl] (Roboto Serif 400 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-8xl] (Roboto Serif 400 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular not-italic text-9xl] (Roboto Serif 400 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-xs] (Roboto Serif 400 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-sm] (Roboto Serif 400 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-base] (Roboto Serif 400 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-lg] (Roboto Serif 400 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-xl] (Roboto Serif 400 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-2xl] (Roboto Serif 400 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-3xl] (Roboto Serif 400 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-4xl] (Roboto Serif 400 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-5xl] (Roboto Serif 400 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-6xl] (Roboto Serif 400 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-7xl] (Roboto Serif 400 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-8xl] (Roboto Serif 400 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-regular italic text-9xl] (Roboto Serif 400 italic 128/100%)"
+            }
+          }
+        },
+        "medium": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-xs] (Roboto Serif 500 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-sm] (Roboto Serif 500 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-base] (Roboto Serif 500 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-lg] (Roboto Serif 500 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-xl] (Roboto Serif 500 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-2xl] (Roboto Serif 500 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-3xl] (Roboto Serif 500 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-4xl] (Roboto Serif 500 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-5xl] (Roboto Serif 500 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-6xl] (Roboto Serif 500 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-7xl] (Roboto Serif 500 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-8xl] (Roboto Serif 500 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium not-italic text-9xl] (Roboto Serif 500 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-xs] (Roboto Serif 500 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-sm] (Roboto Serif 500 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-base] (Roboto Serif 500 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-lg] (Roboto Serif 500 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-xl] (Roboto Serif 500 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-2xl] (Roboto Serif 500 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-3xl] (Roboto Serif 500 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-4xl] (Roboto Serif 500 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-5xl] (Roboto Serif 500 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-6xl] (Roboto Serif 500 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-7xl] (Roboto Serif 500 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-8xl] (Roboto Serif 500 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-medium italic text-9xl] (Roboto Serif 500 italic 128/100%)"
+            }
+          }
+        },
+        "semibold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-xs] (Roboto Serif 600 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-sm] (Roboto Serif 600 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-base] (Roboto Serif 600 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-lg] (Roboto Serif 600 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-xl] (Roboto Serif 600 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-2xl] (Roboto Serif 600 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-3xl] (Roboto Serif 600 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-4xl] (Roboto Serif 600 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-5xl] (Roboto Serif 600 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-6xl] (Roboto Serif 600 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-7xl] (Roboto Serif 600 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-8xl] (Roboto Serif 600 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold not-italic text-9xl] (Roboto Serif 600 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-xs] (Roboto Serif 600 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-sm] (Roboto Serif 600 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-base] (Roboto Serif 600 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-lg] (Roboto Serif 600 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-xl] (Roboto Serif 600 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-2xl] (Roboto Serif 600 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-3xl] (Roboto Serif 600 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-4xl] (Roboto Serif 600 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-5xl] (Roboto Serif 600 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-6xl] (Roboto Serif 600 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-7xl] (Roboto Serif 600 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-8xl] (Roboto Serif 600 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-semibold italic text-9xl] (Roboto Serif 600 italic 128/100%)"
+            }
+          }
+        },
+        "bold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-xs] (Roboto Serif 700 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-sm] (Roboto Serif 700 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-base] (Roboto Serif 700 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-lg] (Roboto Serif 700 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-xl] (Roboto Serif 700 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-2xl] (Roboto Serif 700 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-3xl] (Roboto Serif 700 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-4xl] (Roboto Serif 700 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-5xl] (Roboto Serif 700 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-6xl] (Roboto Serif 700 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-7xl] (Roboto Serif 700 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-8xl] (Roboto Serif 700 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold not-italic text-9xl] (Roboto Serif 700 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-xs] (Roboto Serif 700 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-sm] (Roboto Serif 700 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-base] (Roboto Serif 700 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-lg] (Roboto Serif 700 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-xl] (Roboto Serif 700 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-2xl] (Roboto Serif 700 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-3xl] (Roboto Serif 700 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-4xl] (Roboto Serif 700 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-5xl] (Roboto Serif 700 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-6xl] (Roboto Serif 700 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-7xl] (Roboto Serif 700 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-8xl] (Roboto Serif 700 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-bold italic text-9xl] (Roboto Serif 700 italic 128/100%)"
+            }
+          }
+        },
+        "extrabold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-xs] (Roboto Serif 800 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-sm] (Roboto Serif 800 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-base] (Roboto Serif 800 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-lg] (Roboto Serif 800 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-xl] (Roboto Serif 800 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-2xl] (Roboto Serif 800 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-3xl] (Roboto Serif 800 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-4xl] (Roboto Serif 800 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-5xl] (Roboto Serif 800 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-6xl] (Roboto Serif 800 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-7xl] (Roboto Serif 800 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-8xl] (Roboto Serif 800 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold not-italic text-9xl] (Roboto Serif 800 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-xs] (Roboto Serif 800 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-sm] (Roboto Serif 800 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-base] (Roboto Serif 800 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-lg] (Roboto Serif 800 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-xl] (Roboto Serif 800 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-2xl] (Roboto Serif 800 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-3xl] (Roboto Serif 800 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-4xl] (Roboto Serif 800 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-5xl] (Roboto Serif 800 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-6xl] (Roboto Serif 800 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-7xl] (Roboto Serif 800 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-8xl] (Roboto Serif 800 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-extrabold italic text-9xl] (Roboto Serif 800 italic 128/100%)"
+            }
+          }
+        },
+        "black": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-xs] (Roboto Serif 900 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-sm] (Roboto Serif 900 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-base] (Roboto Serif 900 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-lg] (Roboto Serif 900 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-xl] (Roboto Serif 900 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-2xl] (Roboto Serif 900 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-3xl] (Roboto Serif 900 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-4xl] (Roboto Serif 900 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-5xl] (Roboto Serif 900 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-6xl] (Roboto Serif 900 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-7xl] (Roboto Serif 900 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-8xl] (Roboto Serif 900 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black not-italic text-9xl] (Roboto Serif 900 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-xs] (Roboto Serif 900 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-sm] (Roboto Serif 900 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-base] (Roboto Serif 900 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-lg] (Roboto Serif 900 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-xl] (Roboto Serif 900 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-2xl] (Roboto Serif 900 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-3xl] (Roboto Serif 900 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-4xl] (Roboto Serif 900 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-5xl] (Roboto Serif 900 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-6xl] (Roboto Serif 900 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-7xl] (Roboto Serif 900 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-8xl] (Roboto Serif 900 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.serif}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-serif font-black italic text-9xl] (Roboto Serif 900 italic 128/100%)"
+            }
+          }
+        }
+      },
+      "mono": {
+        "thin": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-xs] (Roboto Mono 100 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-sm] (Roboto Mono 100 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-base] (Roboto Mono 100 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-lg] (Roboto Mono 100 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-xl] (Roboto Mono 100 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-2xl] (Roboto Mono 100 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-3xl] (Roboto Mono 100 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-4xl] (Roboto Mono 100 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-5xl] (Roboto Mono 100 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-6xl] (Roboto Mono 100 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-7xl] (Roboto Mono 100 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-8xl] (Roboto Mono 100 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin not-italic text-9xl] (Roboto Mono 100 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-xs] (Roboto Mono 100 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-sm] (Roboto Mono 100 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-base] (Roboto Mono 100 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-lg] (Roboto Mono 100 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-xl] (Roboto Mono 100 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-2xl] (Roboto Mono 100 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-3xl] (Roboto Mono 100 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-4xl] (Roboto Mono 100 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-5xl] (Roboto Mono 100 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-6xl] (Roboto Mono 100 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-7xl] (Roboto Mono 100 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-8xl] (Roboto Mono 100 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{thin.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-thin italic text-9xl] (Roboto Mono 100 italic 128/100%)"
+            }
+          }
+        },
+        "extralight": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-xs] (Roboto Mono 200 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-sm] (Roboto Mono 200 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-base] (Roboto Mono 200 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-lg] (Roboto Mono 200 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-xl] (Roboto Mono 200 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-2xl] (Roboto Mono 200 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-3xl] (Roboto Mono 200 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-4xl] (Roboto Mono 200 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-5xl] (Roboto Mono 200 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-6xl] (Roboto Mono 200 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-7xl] (Roboto Mono 200 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-8xl] (Roboto Mono 200 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight not-italic text-9xl] (Roboto Mono 200 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-xs] (Roboto Mono 200 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-sm] (Roboto Mono 200 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-base] (Roboto Mono 200 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-lg] (Roboto Mono 200 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-xl] (Roboto Mono 200 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-2xl] (Roboto Mono 200 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-3xl] (Roboto Mono 200 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-4xl] (Roboto Mono 200 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-5xl] (Roboto Mono 200 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-6xl] (Roboto Mono 200 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-7xl] (Roboto Mono 200 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-8xl] (Roboto Mono 200 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extralight.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extralight italic text-9xl] (Roboto Mono 200 italic 128/100%)"
+            }
+          }
+        },
+        "light": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-xs] (Roboto Mono 300 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-sm] (Roboto Mono 300 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-base] (Roboto Mono 300 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-lg] (Roboto Mono 300 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-xl] (Roboto Mono 300 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-2xl] (Roboto Mono 300 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-3xl] (Roboto Mono 300 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-4xl] (Roboto Mono 300 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-5xl] (Roboto Mono 300 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-6xl] (Roboto Mono 300 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-7xl] (Roboto Mono 300 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-8xl] (Roboto Mono 300 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light not-italic text-9xl] (Roboto Mono 300 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-xs] (Roboto Mono 300 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-sm] (Roboto Mono 300 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-base] (Roboto Mono 300 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-lg] (Roboto Mono 300 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-xl] (Roboto Mono 300 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-2xl] (Roboto Mono 300 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-3xl] (Roboto Mono 300 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-4xl] (Roboto Mono 300 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-5xl] (Roboto Mono 300 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-6xl] (Roboto Mono 300 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-7xl] (Roboto Mono 300 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-8xl] (Roboto Mono 300 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{light.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-light italic text-9xl] (Roboto Mono 300 italic 128/100%)"
+            }
+          }
+        },
+        "regular": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-xs] (Roboto Mono 400 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-sm] (Roboto Mono 400 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-base] (Roboto Mono 400 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-lg] (Roboto Mono 400 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-xl] (Roboto Mono 400 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-2xl] (Roboto Mono 400 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-3xl] (Roboto Mono 400 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-4xl] (Roboto Mono 400 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-5xl] (Roboto Mono 400 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-6xl] (Roboto Mono 400 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-7xl] (Roboto Mono 400 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-8xl] (Roboto Mono 400 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular not-italic text-9xl] (Roboto Mono 400 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-xs] (Roboto Mono 400 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-sm] (Roboto Mono 400 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-base] (Roboto Mono 400 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-lg] (Roboto Mono 400 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-xl] (Roboto Mono 400 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-2xl] (Roboto Mono 400 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-3xl] (Roboto Mono 400 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-4xl] (Roboto Mono 400 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-5xl] (Roboto Mono 400 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-6xl] (Roboto Mono 400 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-7xl] (Roboto Mono 400 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-8xl] (Roboto Mono 400 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{regular.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-regular italic text-9xl] (Roboto Mono 400 italic 128/100%)"
+            }
+          }
+        },
+        "medium": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-xs] (Roboto Mono 500 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-sm] (Roboto Mono 500 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-base] (Roboto Mono 500 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-lg] (Roboto Mono 500 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-xl] (Roboto Mono 500 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-2xl] (Roboto Mono 500 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-3xl] (Roboto Mono 500 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-4xl] (Roboto Mono 500 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-5xl] (Roboto Mono 500 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-6xl] (Roboto Mono 500 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-7xl] (Roboto Mono 500 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-8xl] (Roboto Mono 500 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium not-italic text-9xl] (Roboto Mono 500 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-xs] (Roboto Mono 500 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-sm] (Roboto Mono 500 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-base] (Roboto Mono 500 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-lg] (Roboto Mono 500 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-xl] (Roboto Mono 500 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-2xl] (Roboto Mono 500 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-3xl] (Roboto Mono 500 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-4xl] (Roboto Mono 500 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-5xl] (Roboto Mono 500 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-6xl] (Roboto Mono 500 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-7xl] (Roboto Mono 500 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-8xl] (Roboto Mono 500 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{medium.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-medium italic text-9xl] (Roboto Mono 500 italic 128/100%)"
+            }
+          }
+        },
+        "semibold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-xs] (Roboto Mono 600 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-sm] (Roboto Mono 600 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-base] (Roboto Mono 600 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-lg] (Roboto Mono 600 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-xl] (Roboto Mono 600 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-2xl] (Roboto Mono 600 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-3xl] (Roboto Mono 600 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-4xl] (Roboto Mono 600 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-5xl] (Roboto Mono 600 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-6xl] (Roboto Mono 600 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-7xl] (Roboto Mono 600 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-8xl] (Roboto Mono 600 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold not-italic text-9xl] (Roboto Mono 600 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-xs] (Roboto Mono 600 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-sm] (Roboto Mono 600 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-base] (Roboto Mono 600 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-lg] (Roboto Mono 600 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-xl] (Roboto Mono 600 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-2xl] (Roboto Mono 600 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-3xl] (Roboto Mono 600 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-4xl] (Roboto Mono 600 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-5xl] (Roboto Mono 600 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-6xl] (Roboto Mono 600 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-7xl] (Roboto Mono 600 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-8xl] (Roboto Mono 600 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{semibold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-semibold italic text-9xl] (Roboto Mono 600 italic 128/100%)"
+            }
+          }
+        },
+        "bold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-xs] (Roboto Mono 700 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-sm] (Roboto Mono 700 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-base] (Roboto Mono 700 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-lg] (Roboto Mono 700 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-xl] (Roboto Mono 700 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-2xl] (Roboto Mono 700 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-3xl] (Roboto Mono 700 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-4xl] (Roboto Mono 700 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-5xl] (Roboto Mono 700 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-6xl] (Roboto Mono 700 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-7xl] (Roboto Mono 700 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-8xl] (Roboto Mono 700 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold not-italic text-9xl] (Roboto Mono 700 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-xs] (Roboto Mono 700 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-sm] (Roboto Mono 700 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-base] (Roboto Mono 700 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-lg] (Roboto Mono 700 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-xl] (Roboto Mono 700 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-2xl] (Roboto Mono 700 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-3xl] (Roboto Mono 700 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-4xl] (Roboto Mono 700 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-5xl] (Roboto Mono 700 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-6xl] (Roboto Mono 700 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-7xl] (Roboto Mono 700 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-8xl] (Roboto Mono 700 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{bold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-bold italic text-9xl] (Roboto Mono 700 italic 128/100%)"
+            }
+          }
+        },
+        "extrabold": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-xs] (Roboto Mono 800 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-sm] (Roboto Mono 800 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-base] (Roboto Mono 800 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-lg] (Roboto Mono 800 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-xl] (Roboto Mono 800 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-2xl] (Roboto Mono 800 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-3xl] (Roboto Mono 800 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-4xl] (Roboto Mono 800 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-5xl] (Roboto Mono 800 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-6xl] (Roboto Mono 800 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-7xl] (Roboto Mono 800 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-8xl] (Roboto Mono 800 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold not-italic text-9xl] (Roboto Mono 800 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-xs] (Roboto Mono 800 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-sm] (Roboto Mono 800 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-base] (Roboto Mono 800 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-lg] (Roboto Mono 800 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-xl] (Roboto Mono 800 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-2xl] (Roboto Mono 800 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-3xl] (Roboto Mono 800 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-4xl] (Roboto Mono 800 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-5xl] (Roboto Mono 800 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-6xl] (Roboto Mono 800 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-7xl] (Roboto Mono 800 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-8xl] (Roboto Mono 800 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{extrabold.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-extrabold italic text-9xl] (Roboto Mono 800 italic 128/100%)"
+            }
+          }
+        },
+        "black": {
+          "normal": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-xs] (Roboto Mono 900 normal 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-sm] (Roboto Mono 900 normal 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-base] (Roboto Mono 900 normal 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-lg] (Roboto Mono 900 normal 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-xl] (Roboto Mono 900 normal 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-2xl] (Roboto Mono 900 normal 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-3xl] (Roboto Mono 900 normal 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-4xl] (Roboto Mono 900 normal 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-5xl] (Roboto Mono 900 normal 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-6xl] (Roboto Mono 900 normal 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-7xl] (Roboto Mono 900 normal 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-8xl] (Roboto Mono 900 normal 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.normal}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black not-italic text-9xl] (Roboto Mono 900 normal 128/100%)"
+            }
+          },
+          "italic": {
+            "xs": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{4}",
+                "fontSize": "{xs}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-xs] (Roboto Mono 900 italic 12/16)"
+            },
+            "sm": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{5}",
+                "fontSize": "{sm}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-sm] (Roboto Mono 900 italic 14/20)"
+            },
+            "base": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{6}",
+                "fontSize": "{base}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-base] (Roboto Mono 900 italic 16/24)"
+            },
+            "lg": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{lg}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-lg] (Roboto Mono 900 italic 18/28)"
+            },
+            "xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{7}",
+                "fontSize": "{xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-xl] (Roboto Mono 900 italic 20/28)"
+            },
+            "2xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{8}",
+                "fontSize": "{2xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-2xl] (Roboto Mono 900 italic 24/32)"
+            },
+            "3xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{9}",
+                "fontSize": "{3xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-3xl] (Roboto Mono 900 italic 30/36)"
+            },
+            "4xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{10}",
+                "fontSize": "{4xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-4xl] (Roboto Mono 900 italic 36/40)"
+            },
+            "5xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{5xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-5xl] (Roboto Mono 900 italic 48/100%)"
+            },
+            "6xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{6xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-6xl] (Roboto Mono 900 italic 60/100%)"
+            },
+            "7xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{7xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-7xl] (Roboto Mono 900 italic 72/100%)"
+            },
+            "8xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{8xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-8xl] (Roboto Mono 900 italic 96/100%)"
+            },
+            "9xl": {
+              "value": {
+                "fontFamily": "{roboto.mono}",
+                "fontWeight": "{black.italic}",
+                "lineHeight": "{none}",
+                "fontSize": "{9xl}"
+              },
+              "type": "typography",
+              "description": "[font-mono font-black italic text-9xl] (Roboto Mono 900 italic 128/100%)"
+            }
+          }
+        }
+      }
+    }
+  },
+  "$themes": [],
+  "$metadata": {
+    "tokenSetOrder": [
+      "global"
+    ]
+  }
+}


### PR DESCRIPTION
feat(color, typography, fontFamilies, fontWeights, fontSize, lineHeights): init design-tokens

• add `color`: tailwind
• add `typography`: sans, serif, mono
• add `fontFamilies`: roboto (sans, serif, mono)
• add `fontWeights`: thin, extralight, light, regular, medium, semibold, bold, extrabold, black
• add `fontSize`: xs, sm, Base, lg, xl, 2xl, 3xl, 4xl, 5xl, 6xl, 7xl, 8xl, 9xl
 • add `lineHeights`: 3, 4, 5, 6, 7, 8, 9, 10, none, tight, snug, normal, relaxed, loose